### PR TITLE
[chore] update image tag to latest version

### DIFF
--- a/haproxy.yml
+++ b/haproxy.yml
@@ -27,7 +27,7 @@ haproxy:
   containers:
     haproxy:
       image: haproxy
-      image-tag: <- $haproxy-image default("2.7.1")
+      image-tag: <- $haproxy-image default("latest")
       cap-add:
         - CAP_NET_BIND_SERVICE
   files:
@@ -42,7 +42,7 @@ haproxy:
       value: 8080
     haproxy-image:
       type: string
-      value: 2.7.1
+      value: latest
     haproxy-port-number:
       type: int
       value: 8080


### PR DESCRIPTION
This pull request includes changes to the `haproxy.yml` file to update the `haproxy` image version.

* Updated the `haproxy` image tag to use the latest version instead of a specific version.
* Changed the default value of the `haproxy-image` parameter to "latest" from "2.7.1".